### PR TITLE
[feat] 회원가입은 이메일 인증 후에 하도록 구현

### DIFF
--- a/src/main/java/org/example/plzdrawing/PlzdrawingApplication.java
+++ b/src/main/java/org/example/plzdrawing/PlzdrawingApplication.java
@@ -2,8 +2,10 @@ package org.example.plzdrawing;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PlzdrawingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/example/plzdrawing/api/auth/controller/AuthController.java
+++ b/src/main/java/org/example/plzdrawing/api/auth/controller/AuthController.java
@@ -6,14 +6,19 @@ import java.net.URI;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.plzdrawing.api.auth.customuser.CustomUser;
 import org.example.plzdrawing.api.auth.dto.request.LoginRequest;
 import org.example.plzdrawing.api.auth.dto.request.SignUpRequest;
 import org.example.plzdrawing.api.auth.dto.response.LoginResponse;
 import org.example.plzdrawing.api.auth.dto.response.ReissueResponse;
 import org.example.plzdrawing.api.auth.dto.response.SignUpResponse;
 import org.example.plzdrawing.api.auth.service.strategy.AuthService;
+import org.example.plzdrawing.domain.Role;
+import org.example.plzdrawing.domain.member.Provider;
 import org.example.plzdrawing.util.jwt.TokenService;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -31,16 +36,19 @@ public class AuthController {
 
     @PostMapping("/v1/signup")
     @Operation(summary = "회원가입", description = "signUp")
-    public ResponseEntity<SignUpResponse> signUp(@RequestBody @Valid SignUpRequest request) {
-        AuthService authService = strategyManager.getAuthService(request.getProvider());
-
-        Long savedId = authService.signUp(request).getMemberId();
+    public ResponseEntity<SignUpResponse> signUp(
+            @AuthenticationPrincipal CustomUser customUser,
+            @RequestBody @Valid SignUpRequest request) {
+        AuthService authService = strategyManager.getAuthService(Provider.EMAIL);
+        authService.signUp(customUser, request);
+        String accessToken = tokenService.createAccessToken(customUser.getMember().getId().toString(), Role.ROLE_MEMBER);
         URI location = ServletUriComponentsBuilder
                 .fromPath("/api/member/{memberId}")
-                .buildAndExpand(savedId)
+                .buildAndExpand(customUser.getMember().getId().toString())
                 .toUri();
-
-        return ResponseEntity.created(location).build();
+        return ResponseEntity.
+                created(location)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken).build();
     }
 
     @PostMapping("/v1/login")

--- a/src/main/java/org/example/plzdrawing/api/auth/controller/EmailController.java
+++ b/src/main/java/org/example/plzdrawing/api/auth/controller/EmailController.java
@@ -10,6 +10,7 @@ import org.example.plzdrawing.api.auth.dto.request.PasswordResetRequest;
 import org.example.plzdrawing.api.auth.dto.request.UpdatePasswordRequest;
 import org.example.plzdrawing.api.auth.service.strategy.email.EmailService;
 import org.example.plzdrawing.common.annotation.ValidEmail;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,8 +33,9 @@ public class EmailController {
     @Operation(summary = "이메일 인증", description = "verifyEmail")
     public ResponseEntity<Boolean> verifyEmail(@RequestParam("email") @ValidEmail String email,
             @RequestParam("code") String authCode) {
-
-        return ResponseEntity.ok(emailService.verifyAuthCode(email, authCode));
+        return ResponseEntity.ok()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + emailService.verifyAuthCode(email, authCode)) // 헤더에 추가
+                .body(true);
     }
 
     @PostMapping("/v1/password/reissue")

--- a/src/main/java/org/example/plzdrawing/api/auth/customuser/CustomUser.java
+++ b/src/main/java/org/example/plzdrawing/api/auth/customuser/CustomUser.java
@@ -1,22 +1,27 @@
 package org.example.plzdrawing.api.auth.customuser;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import lombok.Getter;
+import org.example.plzdrawing.domain.member.Member;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
 public class CustomUser implements UserDetails {
 
-    private final String memberId;
+    private final Member member;
 
-    public CustomUser(String memberId) {
-        this.memberId = memberId;
+    public CustomUser(Member member) {
+        this.member = member;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add(new SimpleGrantedAuthority(member.getRole().name()));
+        return collection;
     }
 
     @Override

--- a/src/main/java/org/example/plzdrawing/api/auth/customuser/CustomUserService.java
+++ b/src/main/java/org/example/plzdrawing/api/auth/customuser/CustomUserService.java
@@ -3,6 +3,7 @@ package org.example.plzdrawing.api.auth.customuser;
 
 import lombok.RequiredArgsConstructor;
 import org.example.plzdrawing.api.member.service.MemberService;
+import org.example.plzdrawing.domain.member.Member;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -17,7 +18,7 @@ public class CustomUserService implements UserDetailsService {
     @Override
     @Transactional(readOnly = true)
     public CustomUser loadUserByUsername(String username) throws UsernameNotFoundException {
-        memberService.findById(Long.valueOf(username));
-        return new CustomUser(username);
+        Member member = memberService.findById(Long.valueOf(username));
+        return new CustomUser(member);
     }
 }

--- a/src/main/java/org/example/plzdrawing/api/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/org/example/plzdrawing/api/auth/dto/request/SignUpRequest.java
@@ -4,13 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.example.plzdrawing.common.annotation.ValidEmail;
 import org.example.plzdrawing.common.annotation.ValidPassword;
-import org.example.plzdrawing.domain.member.Provider;
 
 @Getter
 public class SignUpRequest {
-
-    @Schema(description = "제공자", example = "EMAIL / KAKAO / NAVER")
-    private Provider provider;
 
     @ValidEmail
     @Schema(description = "이메일", example = "abc@def.com")
@@ -22,4 +18,13 @@ public class SignUpRequest {
 
     @Schema(description = "닉네임", example = "abc")
     private String nickName;
+
+    @Schema(description = "약관동의(개인정보 수집 및 이용)", example = "true")
+    private Boolean personalInfoConsent;
+
+    @Schema(description = "이용정책 동의", example = "true")
+    private Boolean acceptTermsOfUse;
+
+    @Schema(description = "할인, 이벤트 소식 받기 동의", example = "false")
+    private Boolean marketingConsent;
 }

--- a/src/main/java/org/example/plzdrawing/api/auth/exception/AuthErrorCode.java
+++ b/src/main/java/org/example/plzdrawing/api/auth/exception/AuthErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode{
-    AUTH_CODE_INCORRECT(new BaseErrorCode("AUTH_001", HttpStatus.UNAUTHORIZED, "인증번호가 일치하지 않습니다."))
-    ;
+    AUTH_CODE_INCORRECT(new BaseErrorCode("AUTH_001", HttpStatus.UNAUTHORIZED, "인증번호가 일치하지 않습니다.")),
+    MEMBER_NOT_EXIST(new BaseErrorCode("AUTH_002", HttpStatus.NOT_FOUND, "해당 멤버를 찾을 수 없습니다.")),
+    EXIST_EMAIL(new BaseErrorCode("AUTH_003", HttpStatus.BAD_REQUEST, "이미 존재하는 이메일 입니다."));
     private final ErrorCode errorCode;
 }

--- a/src/main/java/org/example/plzdrawing/api/auth/service/mail/SendMailService.java
+++ b/src/main/java/org/example/plzdrawing/api/auth/service/mail/SendMailService.java
@@ -1,6 +1,7 @@
 package org.example.plzdrawing.api.auth.service.mail;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.mail.javamail.MimeMessagePreparator;
@@ -12,11 +13,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SendMailService {
 
+    @Value("${spring.mail.username}")
+    private String fromAddress;
+
     private final JavaMailSender emailSender;
 
     public void sendEmail(String to, String subject, String content) {
         MimeMessagePreparator messagePreparer = mimeMessage -> {
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+            helper.setFrom(fromAddress);
             helper.setTo(to);
             helper.setSubject(subject);
             helper.setText(content);

--- a/src/main/java/org/example/plzdrawing/api/auth/service/strategy/AuthService.java
+++ b/src/main/java/org/example/plzdrawing/api/auth/service/strategy/AuthService.java
@@ -1,5 +1,6 @@
 package org.example.plzdrawing.api.auth.service.strategy;
 
+import org.example.plzdrawing.api.auth.customuser.CustomUser;
 import org.example.plzdrawing.api.auth.dto.request.LoginRequest;
 import org.example.plzdrawing.api.auth.dto.request.SignUpRequest;
 import org.example.plzdrawing.api.auth.dto.response.LoginResponse;
@@ -10,7 +11,7 @@ public interface AuthService {
 
     LoginResponse login(LoginRequest request);
 
-    SignUpResponse signUp(SignUpRequest request);
+    SignUpResponse signUp(CustomUser customUser, SignUpRequest request);
 
     Provider getProviderName();
 }

--- a/src/main/java/org/example/plzdrawing/api/auth/service/strategy/KakaoService.java
+++ b/src/main/java/org/example/plzdrawing/api/auth/service/strategy/KakaoService.java
@@ -1,6 +1,7 @@
 package org.example.plzdrawing.api.auth.service.strategy;
 
 import lombok.RequiredArgsConstructor;
+import org.example.plzdrawing.api.auth.customuser.CustomUser;
 import org.example.plzdrawing.api.auth.dto.request.LoginRequest;
 import org.example.plzdrawing.api.auth.dto.request.SignUpRequest;
 import org.example.plzdrawing.api.auth.dto.response.LoginResponse;
@@ -20,7 +21,7 @@ public class KakaoService implements AuthService {
     }
 
     @Override
-    public SignUpResponse signUp(SignUpRequest request) {
+    public SignUpResponse signUp(CustomUser customUser, SignUpRequest request) {
         return null;
     }
 

--- a/src/main/java/org/example/plzdrawing/api/auth/service/strategy/NaverService.java
+++ b/src/main/java/org/example/plzdrawing/api/auth/service/strategy/NaverService.java
@@ -1,6 +1,7 @@
 package org.example.plzdrawing.api.auth.service.strategy;
 
 import lombok.RequiredArgsConstructor;
+import org.example.plzdrawing.api.auth.customuser.CustomUser;
 import org.example.plzdrawing.api.auth.dto.request.LoginRequest;
 import org.example.plzdrawing.api.auth.dto.request.SignUpRequest;
 import org.example.plzdrawing.api.auth.dto.response.LoginResponse;
@@ -20,7 +21,7 @@ public class NaverService implements AuthService{
     }
 
     @Override
-    public SignUpResponse signUp(SignUpRequest request) {
+    public SignUpResponse signUp(CustomUser customUser, SignUpRequest request) {
         return null;
     }
 

--- a/src/main/java/org/example/plzdrawing/api/auth/service/strategy/email/EmailService.java
+++ b/src/main/java/org/example/plzdrawing/api/auth/service/strategy/email/EmailService.java
@@ -5,7 +5,7 @@ import org.example.plzdrawing.api.auth.service.strategy.AuthService;
 public interface EmailService extends AuthService {
 
     void sendCode(String email);
-    Boolean verifyAuthCode(String email, String authCode);
+    String verifyAuthCode(String email, String authCode);
     void sendEmailForRecoveryPassword(String email);
     Boolean reissuePassword(String email, String authCode);
     void changePassword(String email, String nowPassword, String newPassword);

--- a/src/main/java/org/example/plzdrawing/common/config/security/SecurityConfig.java
+++ b/src/main/java/org/example/plzdrawing/common/config/security/SecurityConfig.java
@@ -18,7 +18,14 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     private static final String[] AUTH_WHITELIST = {
-            "/**"
+            "/",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/api/auth/email/v1/**"
+    };
+
+    private static final String[] AUTH_TEMP = {
+        "/api/auth/v1/signup"
     };
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
@@ -30,9 +37,9 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((authorizeRequests) ->
-                        authorizeRequests.requestMatchers(AUTH_WHITELIST)
-                                .permitAll()
-                                .anyRequest().authenticated())
+                        authorizeRequests.requestMatchers(AUTH_WHITELIST).permitAll()
+                                .requestMatchers(AUTH_TEMP).hasRole("TEMP")
+                                .anyRequest().hasRole("MEMBER"))
                 .addFilterBefore(jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/org/example/plzdrawing/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/org/example/plzdrawing/common/config/swagger/SwaggerConfig.java
@@ -1,45 +1,50 @@
 package org.example.plzdrawing.common.config.swagger;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.info.Contact;
-import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.servers.Server;
+
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.security.SecurityScheme.In;
-import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-
-@OpenAPIDefinition(
-        servers = @Server(url = "/", description = "Default Server URL"),
-        info = @Info(
-                title = "PlzDrawing 백엔드 API 명세",
-                description = "springdoc을 이용한 Swagger API 문서입니다.",
-                version = "1.0",
-                contact = @Contact(
-                        name = "springdoc 공식문서",
-                        url = "https://springdoc.org/"
-                )
-        )
-)
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @Configuration
+@EnableWebMvc
 public class SwaggerConfig {
     @Bean
-    public OpenAPI customOpenAPI() {
+    public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components().addSecuritySchemes("JWT", bearerAuth()));
+                .servers(List.of(
+                        new io.swagger.v3.oas.models.servers.Server().url("http://localhost:8080").description("Local Server")
+                ))
+                .components(components())
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement());
     }
 
-    public SecurityScheme bearerAuth() {
-        return new SecurityScheme()
-                .type(Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("JWT")
-                .in(In.HEADER)
-                .name(HttpHeaders.AUTHORIZATION);
+    private io.swagger.v3.oas.models.info.Info apiInfo() {
+        return new io.swagger.v3.oas.models.info.Info()
+                .title("Plzdrawing API Docs")
+                .description("플리즈드로잉 관련 spring 서버 Api Document 입니다.");
+    }
+
+    // JWT 토큰을 위한 보안 컴포넌트 설정
+    private Components components() {
+        String securityScheme = "JWT TOKEN";
+        return new Components()
+                .addSecuritySchemes(securityScheme, new SecurityScheme()
+                        .name(securityScheme)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT"));
+    }
+
+    // 보안 요구사항 설정
+    private SecurityRequirement securityRequirement() {
+        String securityScheme = "JWT TOKEN";
+        return new SecurityRequirement().addList(securityScheme);
     }
 }

--- a/src/main/java/org/example/plzdrawing/common/scheduler/DeleteTempMemberScheduler.java
+++ b/src/main/java/org/example/plzdrawing/common/scheduler/DeleteTempMemberScheduler.java
@@ -1,13 +1,23 @@
 package org.example.plzdrawing.common.scheduler;
 
+import static org.example.plzdrawing.domain.Role.ROLE_TEMP;
+
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.example.plzdrawing.domain.member.MemberRepository;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 public class DeleteTempMemberScheduler {
     private final MemberRepository memberRepository;
 
-
+    @Scheduled(cron = "0 0 0 * * ?")
+    @Transactional
+    public void deleteTempMember() {
+        LocalDateTime threshold = LocalDateTime.now().minusHours(24);
+        memberRepository.deleteByEmailAndRoleBeforeThreshold(ROLE_TEMP, threshold);
+    }
 }

--- a/src/main/java/org/example/plzdrawing/common/scheduler/DeleteTempMemberScheduler.java
+++ b/src/main/java/org/example/plzdrawing/common/scheduler/DeleteTempMemberScheduler.java
@@ -1,0 +1,13 @@
+package org.example.plzdrawing.common.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.example.plzdrawing.domain.member.MemberRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteTempMemberScheduler {
+    private final MemberRepository memberRepository;
+
+
+}

--- a/src/main/java/org/example/plzdrawing/domain/Role.java
+++ b/src/main/java/org/example/plzdrawing/domain/Role.java
@@ -1,0 +1,5 @@
+package org.example.plzdrawing.domain;
+
+public enum Role {
+    ROLE_TEMP, ROLE_MEMBER
+}

--- a/src/main/java/org/example/plzdrawing/domain/member/MemberRepository.java
+++ b/src/main/java/org/example/plzdrawing/domain/member/MemberRepository.java
@@ -1,8 +1,10 @@
 package org.example.plzdrawing.domain.member;
 
 import java.util.Optional;
+import org.example.plzdrawing.domain.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +13,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("select m from Member m "
             + "where m.email=:email and m.provider=:provider")
     Optional<Member> findByEmailAndProvider(String email, Provider provider);
+
+    @Query("select m from Member m "
+            + "where m.role=:role and m.provider=:provider and m.email=:email")
+    Optional<Member> findByRoleAndProviderAndEmail(@Param("role") Role role, @Param("provider") Provider provider, @Param("email") String email);
+
+
 }

--- a/src/main/java/org/example/plzdrawing/domain/member/MemberRepository.java
+++ b/src/main/java/org/example/plzdrawing/domain/member/MemberRepository.java
@@ -1,8 +1,10 @@
 package org.example.plzdrawing.domain.member;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.example.plzdrawing.domain.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -18,5 +20,14 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             + "where m.role=:role and m.provider=:provider and m.email=:email")
     Optional<Member> findByRoleAndProviderAndEmail(@Param("role") Role role, @Param("provider") Provider provider, @Param("email") String email);
 
-
+    @Modifying
+    @Query("""
+    DELETE FROM Member m
+    WHERE m.role = :role
+      AND m.createdAt <= :threshold
+""")
+    void deleteByEmailAndRoleBeforeThreshold(
+            @Param("role") Role role,
+            @Param("threshold") LocalDateTime threshold
+    );
 }

--- a/src/main/java/org/example/plzdrawing/util/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/example/plzdrawing/util/jwt/JwtTokenProvider.java
@@ -15,6 +15,7 @@ import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.example.plzdrawing.api.auth.repository.RefreshTokenRedisRepository;
 import org.example.plzdrawing.common.exception.RestApiException;
+import org.example.plzdrawing.domain.Role;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -33,9 +34,10 @@ public class JwtTokenProvider {
 
     private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
-    public String createAccessToken(String memberId) {
+    public String createAccessToken(String memberId, Role role) {
         return Jwts.builder()
                 .subject(memberId)
+                .claim("role", role)
                 .signWith(getSigningKey())
                 .expiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
                 .compact();
@@ -99,7 +101,6 @@ public class JwtTokenProvider {
                 .verifyWith(getSigningKey())
                 .build()
                 .parseSignedClaims(token);
-
         return claims.getPayload().getSubject();
     }
 


### PR DESCRIPTION
## 🛰️ Issue Number
- close :  #19 
## 🪐 작업 내용
- 회원가입은 이메일 인증 후에 하도록 구현
- 이메일 중복(이메일을 인증하려했는데 이미 같은 이메일을 가진 MEMBER권한(정식으로 회원가입까지 끝마친 사람)을 가진 사람이 이미 DB에 있으면 Exception반환)
- 스케쥴러 구현(24시간마다 돌리는데 create_at으로부터 하루가 지난 TEMP멤버 엔티티를 일괄 삭제)
## 📚 Reference
- 

## ✅ Check List
- [x] 코드 작성 시 최선을 다했나요?
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 작성 및 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 🔉 같이 고민하고 싶은 부분 (없으면 생략)
- 
